### PR TITLE
Fix: Implement api for domain counter

### DIFF
--- a/components/UI/titles/domainCountTitle.tsx
+++ b/components/UI/titles/domainCountTitle.tsx
@@ -16,7 +16,7 @@ const DomainCountTitle: FunctionComponent<CategoryTitleProps> = ({
   subtitle,
   button,
 }) => {
-  const [domainCount, setDomainCount] = useState(136000);
+  const [domainCount, setDomainCount] = useState(1356000);
   useEffect(() => {
     const fetchDomainCount = async () => {
       try {

--- a/components/UI/titles/domainCountTitle.tsx
+++ b/components/UI/titles/domainCountTitle.tsx
@@ -1,4 +1,9 @@
-import React, { FunctionComponent, ReactNode } from "react";
+import React, {
+  FunctionComponent,
+  ReactNode,
+  useEffect,
+  useState,
+} from "react";
 import styles from "../../../styles/components/titles.module.css";
 import Counter from "../../home/counterComponent";
 
@@ -11,9 +16,28 @@ const DomainCountTitle: FunctionComponent<CategoryTitleProps> = ({
   subtitle,
   button,
 }) => {
+  const [domainCount, setDomainCount] = useState(136000);
+  useEffect(() => {
+    const fetchDomainCount = async () => {
+      try {
+        const response = await fetch(
+          `${process.env.NEXT_PUBLIC_SERVER_LINK}/stats/count_minted_domains`
+        );
+        if (response.ok) {
+          const data = await response.json();
+          console.log(data);
+          setDomainCount(data.count);
+        }
+      } catch (error) {
+        console.error("Failed to fetch domain count:", error);
+      }
+    };
+
+    fetchDomainCount();
+  }, []);
   return (
     <div className={styles.domainCountTitleContainer}>
-      <Counter />
+      <Counter finalValue={domainCount} />
       <p className={styles.domainCountSubtitle}>{subtitle}</p>
       {button}
     </div>

--- a/components/UI/titles/domainCountTitle.tsx
+++ b/components/UI/titles/domainCountTitle.tsx
@@ -25,7 +25,6 @@ const DomainCountTitle: FunctionComponent<CategoryTitleProps> = ({
         );
         if (response.ok) {
           const data = await response.json();
-          console.log(data);
           setDomainCount(data.count);
         }
       } catch (error) {

--- a/components/home/counterComponent.tsx
+++ b/components/home/counterComponent.tsx
@@ -49,7 +49,7 @@ useEffect(() => {
    }, step);
    
    return () => clearInterval(timer);
- }, [hasStarted]);
+ }, [finalValue, hasStarted]);
  
  return <h2 ref={ref} id='count' className={styles.domainCountTitle}>{count.toLocaleString()}</h2>;
 };

--- a/components/home/counterComponent.tsx
+++ b/components/home/counterComponent.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useRef, useState } from 'react';
 import styles from "../../styles/components/titles.module.css";
+import { ICounter } from '../../types/frontTypes';
 
-const Counter: React.FC = () => {
+const Counter: React.FC<ICounter> = ({finalValue}) => {
  const [count, setCount] = useState(0);
  const [hasStarted, setHasStarted] = useState(false);
  const ref = useRef<HTMLHeadingElement | null>(null);
@@ -13,7 +14,7 @@ const Counter: React.FC = () => {
         setHasStarted(true);
       }
     },
-    { threshold: 0.5 } // Adjust threshold as needed
+    { threshold: 0.5 } 
   );
 
   if (ref.current) observer.observe(ref.current);
@@ -21,10 +22,11 @@ const Counter: React.FC = () => {
   return () => observer.disconnect();
 }, [hasStarted]);
 
- useEffect(() => {
+
+useEffect(() => {
  if (!hasStarted) return;
  
-   const end = 475736;
+   const end = finalValue;
    const duration = 5000;
    const range = end;
    const step = Math.floor(duration / range);

--- a/components/home/counterComponent.tsx
+++ b/components/home/counterComponent.tsx
@@ -1,10 +1,29 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import styles from "../../styles/components/titles.module.css";
 
 const Counter: React.FC = () => {
  const [count, setCount] = useState(0);
- 
+ const [hasStarted, setHasStarted] = useState(false);
+ const ref = useRef<HTMLHeadingElement | null>(null);
+
  useEffect(() => {
+  const observer = new IntersectionObserver(
+    ([entry]) => {
+      if (entry.isIntersecting && !hasStarted) {
+        setHasStarted(true);
+      }
+    },
+    { threshold: 0.5 } // Adjust threshold as needed
+  );
+
+  if (ref.current) observer.observe(ref.current);
+
+  return () => observer.disconnect();
+}, [hasStarted]);
+
+ useEffect(() => {
+ if (!hasStarted) return;
+ 
    const end = 475736;
    const duration = 5000;
    const range = end;
@@ -28,9 +47,9 @@ const Counter: React.FC = () => {
    }, step);
    
    return () => clearInterval(timer);
- }, []);
+ }, [hasStarted]);
  
- return <h2 id='count' className={styles.domainCountTitle}>{count.toLocaleString()}</h2>;
+ return <h2 ref={ref} id='count' className={styles.domainCountTitle}>{count.toLocaleString()}</h2>;
 };
 
 export default Counter;

--- a/components/home/counterComponent.tsx
+++ b/components/home/counterComponent.tsx
@@ -1,57 +1,60 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from "react";
 import styles from "../../styles/components/titles.module.css";
-import { ICounter } from '../../types/frontTypes';
+import { ICounter } from "../../types/frontTypes";
 
-const Counter: React.FC<ICounter> = ({finalValue}) => {
- const [count, setCount] = useState(0);
- const [hasStarted, setHasStarted] = useState(false);
- const ref = useRef<HTMLHeadingElement | null>(null);
+const Counter: React.FC<ICounter> = ({ finalValue }) => {
+  const [count, setCount] = useState(0);
+  const [hasStarted, setHasStarted] = useState(false);
+  const ref = useRef<HTMLHeadingElement | null>(null);
 
- useEffect(() => {
-  const observer = new IntersectionObserver(
-    ([entry]) => {
-      if (entry.isIntersecting && !hasStarted) {
-        setHasStarted(true);
+  useEffect(() => {
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting && !hasStarted) {
+          setHasStarted(true);
+        }
+      },
+      { threshold: 0.5 }
+    );
+
+    if (ref.current) observer.observe(ref.current);
+
+    return () => observer.disconnect();
+  }, [hasStarted]);
+
+  useEffect(() => {
+    if (!hasStarted) return;
+
+    const end = finalValue;
+    const duration = 5000;
+    const range = end;
+    const step = Math.floor(duration / range);
+
+    const startTime = Date.now();
+
+    const timer = setInterval(() => {
+      const elapsed = Date.now() - startTime;
+
+      if (elapsed >= duration) {
+        setCount(end);
+        clearInterval(timer);
+        return;
       }
-    },
-    { threshold: 0.5 } 
+
+      const progress = elapsed / duration;
+      const nextCount = Math.min(Math.ceil(range * progress), end);
+
+      setCount(nextCount);
+    }, step);
+
+    return () => clearInterval(timer);
+  }, [finalValue, hasStarted]);
+
+  return (
+    <h2 ref={ref} id="count" className={styles.domainCountTitle}>
+      {count.toLocaleString()}
+    </h2>
   );
-
-  if (ref.current) observer.observe(ref.current);
-
-  return () => observer.disconnect();
-}, [hasStarted]);
-
-
-useEffect(() => {
- if (!hasStarted) return;
- 
-   const end = finalValue;
-   const duration = 5000;
-   const range = end;
-   const step = Math.floor(duration / range);
-   
-   const startTime = Date.now();
-   
-   const timer = setInterval(() => {
-     const elapsed = Date.now() - startTime;
-     
-     if (elapsed >= duration) {
-       setCount(end);
-       clearInterval(timer);
-       return;
-     }
-     
-     const progress = elapsed / duration;
-     const nextCount = Math.min(Math.ceil(range * progress), end);
-     
-     setCount(nextCount);
-   }, step);
-   
-   return () => clearInterval(timer);
- }, [finalValue, hasStarted]);
- 
- return <h2 ref={ref} id='count' className={styles.domainCountTitle}>{count.toLocaleString()}</h2>;
 };
 
 export default Counter;

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,20 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.26.2",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.26.2.tgz",
@@ -67,6 +81,47 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.26.5.tgz",
+      "integrity": "sha512-XvcZi1KWf88RVbF9wn8MN6tYFloU5qX8KjuF3E1PVBmJ9eypXfs4GRiJwLuTZL0iSnJUKn1BFPa5BPZZJyFzPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.7.tgz",
+      "integrity": "sha512-SRijHmF0PSPgLIBYlWnG0hyeJLwXE2CgpsXaMOrtt2yp9/86ALw6oUlj9KYuZ0JN07T4eBMVIW4li/9S1j2BGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.2.0",
+        "@babel/code-frame": "^7.26.2",
+        "@babel/generator": "^7.26.5",
+        "@babel/helper-compilation-targets": "^7.26.5",
+        "@babel/helper-module-transforms": "^7.26.0",
+        "@babel/helpers": "^7.26.7",
+        "@babel/parser": "^7.26.7",
+        "@babel/template": "^7.25.9",
+        "@babel/traverse": "^7.26.7",
+        "@babel/types": "^7.26.7",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
       }
     },
     "node_modules/@babel/generator": {
@@ -97,6 +152,23 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.26.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.26.5.tgz",
+      "integrity": "sha512-IXuyn5EkouFJscIDuFF5EsiSolseme1s0CZB+QxVugqJLYmKdxI1VfIBOst0SUu4rnk2Z7kqTwmoO1lp3HIfnA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/compat-data": "^7.26.5",
+        "@babel/helper-validator-option": "^7.25.9",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/helper-module-imports": {
       "version": "7.25.9",
       "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.25.9.tgz",
@@ -108,6 +180,24 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.26.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.26.0.tgz",
+      "integrity": "sha512-xO+xu6B5K2czEnQye6BHA7DolFFmS3LB7stHZFaOLb1pAwO1HWLS8fXA+eh0A2yIvltPVmx3eNNDBJA2SLHXFw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.25.9",
+        "@babel/helper-validator-identifier": "^7.25.9",
+        "@babel/traverse": "^7.25.9"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
       }
     },
     "node_modules/@babel/helper-plugin-utils": {
@@ -133,6 +223,30 @@
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.25.9.tgz",
       "integrity": "sha512-Ed61U6XJc3CVRfkERJWDz4dJwKe7iLmmJsbOGu9wSloNSFttHV0I8g6UAgb7qnK5ly5bGLPd4oXZlxCdANBOWQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.25.9",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.25.9.tgz",
+      "integrity": "sha512-e/zv1co8pp55dNdEcCynfj9X7nyUKUXoUEwfXqaZt0omVOmDe9oOTdKStH4GmAw6zxMFs50ZayuMfHDKlO7Tfw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.26.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.26.7.tgz",
+      "integrity": "sha512-8NHiL98vsi0mbPQmYAGWwfcFaOy4j2HY49fXJCfuDcdE7fMIsH9a7GdaeXpIBsbT7307WU8KCMp5pUVDNL4f9A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/template": "^7.25.9",
+        "@babel/types": "^7.26.7"
+      },
       "engines": {
         "node": ">=6.9.0"
       }
@@ -1245,7 +1359,6 @@
       "version": "18.0.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.0.17.tgz",
       "integrity": "sha512-38ETy4tL+rn4uQQi7mB81G7V1g0u2ryquNmsVIOKUAEIDK+3CUjZ6rSRpdvS99dNBnkLFL83qfmtLacGOTIhwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/prop-types": "*",
@@ -1276,7 +1389,6 @@
       "version": "0.23.0",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.23.0.tgz",
       "integrity": "sha512-YIoDCTH3Af6XM5VuwGG/QL/CJqga1Zm3NkU3HZ4ZHK2fRMPYP1VczsTUqtsf43PH/iJNVlPHAo2oWX7BSdB2Hw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/parser": {
@@ -1888,7 +2000,6 @@
       "version": "4.24.4",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
       "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -2163,6 +2274,13 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/core-util-is": {
       "version": "1.0.3",
@@ -2482,7 +2600,6 @@
       "version": "1.5.88",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.88.tgz",
       "integrity": "sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/emoji-regex": {
@@ -3464,6 +3581,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/get-caller-file": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
@@ -4367,6 +4494,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/jsonfile": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
@@ -4504,6 +4644,16 @@
       "resolved": "https://registry.npmjs.org/lossless-json/-/lossless-json-4.0.2.tgz",
       "integrity": "sha512-+z0EaLi2UcWi8MZRxA5iTb6m4Ys4E80uftGY+yG5KNFJb5EceQXOhdW/pWJZ8m97s26u7yZZAYMcKWNztSZssA==",
       "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -4757,7 +4907,6 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/normalize-path": {
@@ -5792,7 +5941,6 @@
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
       "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -6818,7 +6966,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
       "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -7085,6 +7232,13 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/yaml": {
       "version": "1.10.2",

--- a/types/frontTypes.d.ts
+++ b/types/frontTypes.d.ts
@@ -53,3 +53,7 @@ interface ExtendedVerifierData {
   field: string;
   extended_data: string[];
 }
+
+export interface ICounter{
+  finalValue : number;
+}


### PR DESCRIPTION
Changes:

[x] Update components/UI/titles/domainCountTitle.tsx to make a GET request to the /stats/count_minted_domains API endpoint.
[x] Parse the response to retrieve the count value from the API response.
[x] Display the count value dynamically in the UI.
[x] Implement a fallback value of 136000 while the data is loading or if the request fails.

Closes Issue #100 