### PR TITLE
Fix: Feedback footer - Fix the 'Newsletter' Link Redirect

### DIFF
--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -54,7 +54,7 @@ export default function Footer() {
                   <Link
                     href="https://app.starknet.id/"
                     target="_blank"
-                      rel="noopener noreferrer"
+                    rel="noopener noreferrer"
                     className="opacity-70 font-light transition-opacity"
                   >
                     Get Your Domain
@@ -66,7 +66,7 @@ export default function Footer() {
                     PFP Collections
                   </Link>
                   <Link
-                    href="/"
+                    href="https://app.starknet.id/newsletter"
                     className="opacity-70 font-light transition-opacity"
                   >
                     Newsletter

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -67,6 +67,8 @@ export default function Footer() {
                   </Link>
                   <Link
                     href="https://app.starknet.id/newsletter"
+                    target="_blank"
+                    rel="noopener noreferrer"
                     className="opacity-70 font-light transition-opacity"
                   >
                     Newsletter


### PR DESCRIPTION
This link 'Newsletter' does not redirect to the correct location. Here is the correct link to use: https://app.starknet.id/newsletter

close: #124